### PR TITLE
Add ability to remove session from tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,10 @@
 					"light": "resources/imgs/phase-dark.svg",
 					"dark": "resources/imgs/phase-light.svg"
 				}
+			},
+			{
+				"command": "cics-extension-for-zowe.removeSession",
+				"title": "Remove Session"
 			}
 		],
 		"menus": {
@@ -139,6 +143,11 @@
 					"when": "view == cics-view && viewItem =~ /^cicsprogram.enabled.*/",
 					"command": "cics-extension-for-zowe.disableProgram",
 					"group": ""
+				},
+				{
+					"when": "view == cics-view && viewItem =~ /^cicssession.*/",
+					"command": "cics-extension-for-zowe.removeSession",
+					"title": "Remove Session"
 				}
 			]
 		}

--- a/src/commands/removeSessionCommand.ts
+++ b/src/commands/removeSessionCommand.ts
@@ -1,0 +1,16 @@
+import { CICSTreeDataProvider } from "../trees/treeProvider";
+import { commands, window } from "vscode";
+
+export function getRemoveSessionCommand(tree: CICSTreeDataProvider) {
+  return commands.registerCommand(
+    "cics-extension-for-zowe.removeSession",
+    async (node) => {
+      if (node) {
+        await tree.removeSession(node);
+        tree.refresh();
+      } else {
+        window.showErrorMessage("No CICS program selected");
+      }
+    }
+  );
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import {
   getShowAttributesCommand,
   getShowRegionAttributes,
 } from "./commands/showAttributesCommand";
+import { getRemoveSessionCommand } from "./commands/removeSessionCommand";
 
 export async function activate(context: ExtensionContext) {
   const treeDataProv = new CICSTreeDataProvider();
@@ -31,7 +32,8 @@ export async function activate(context: ExtensionContext) {
     getPhaseInCommand(treeDataProv),
     getShowRegionAttributes(),
     getEnableProgramCommand(treeDataProv),
-    getDisableProgramCommand(treeDataProv)
+    getDisableProgramCommand(treeDataProv),
+    getRemoveSessionCommand(treeDataProv)
   );
 
   const zoweExplorerApi = extensions.getExtension(

--- a/src/trees/CICSSessionTree.ts
+++ b/src/trees/CICSSessionTree.ts
@@ -38,6 +38,7 @@ export class CICSSessionTreeItem extends TreeItem {
     this.session = session;
     this.cicsPlex = cicsPlex;
     this.children = [];
+    this.contextValue = `cicssession.${sessionName}`;
   }
 
   public addRegionChild(region: CICSRegionTreeItem) {

--- a/src/trees/treeProvider.ts
+++ b/src/trees/treeProvider.ts
@@ -17,6 +17,11 @@ import {
 
 export class CICSTreeDataProvider
   implements TreeDataProvider<CICSSessionTreeItem> {
+  removeSession(session: CICSSessionTreeItem) {
+    this.sessionMap.delete(session.sessionName);
+    this.refresh();
+  }
+
   private _onDidChangeTreeData: EventEmitter<
     any | undefined
   > = new EventEmitter<any | undefined>();
@@ -42,97 +47,96 @@ export class CICSTreeDataProvider
   }
 
   async refresh(): Promise<void> {
-    this.showStatusBarItem();
     try {
-      if (this.sessionMap.size > 0) {
-        let profileList = [];
+      this.showStatusBarItem();
+      let profileList = [];
 
-        const listOfSessionTrees: CICSSessionTreeItem[] = [];
+      const listOfSessionTrees: CICSSessionTreeItem[] = [];
 
-        for (const element of this.sessionMap) {
-          const sessionName = element[0];
-          const { session, cicsPlex, region } = element[1];
+      for (const element of this.sessionMap) {
+        const sessionName = element[0];
+        const { session, cicsPlex, region } = element[1];
 
-          const sessionTreeItem = new CICSSessionTreeItem(
-            sessionName,
-            session,
-            cicsPlex
+        const sessionTreeItem = new CICSSessionTreeItem(
+          sessionName,
+          session,
+          cicsPlex
+        );
+
+        const getRegions = await getResource(session, {
+          name: "CICSRegion",
+          regionName: region!,
+          cicsPlex: cicsPlex!,
+          criteria: undefined,
+          parameter: undefined,
+        });
+
+        const listOfRegions: any[] = !Array.isArray(
+          getRegions.response.records.cicsregion
+        )
+          ? [getRegions.response.records.cicsregion]
+          : getRegions.response.records.cicsregion;
+
+        const listOfRegionNames: string[] = listOfRegions.map(
+          (region: { applid: string }) => region.applid
+        );
+
+        const regions = [];
+
+        for (const region of listOfRegions) {
+          const regionTreeItem = new CICSRegionTreeItem(
+            region.applid,
+            sessionTreeItem,
+            region,
+            []
           );
 
-          const getRegions = await getResource(session, {
-            name: "CICSRegion",
-            regionName: region!,
+          const getPrograms = await getResource(session, {
+            name: "CICSProgram",
+            regionName: region.applid,
             cicsPlex: cicsPlex!,
-            criteria: undefined,
+            criteria:
+              "NOT (PROGRAM=CEE* OR PROGRAM=DFH* OR PROGRAM=CJ* OR PROGRAM=EYU* OR PROGRAM=CSQ* OR PROGRAM=CEL* OR PROGRAM=IGZ*)",
             parameter: undefined,
           });
 
-          const listOfRegions: any[] = !Array.isArray(
-            getRegions.response.records.cicsregion
+          const listOfPrograms = !Array.isArray(
+            getPrograms.response.records.cicsprogram
           )
-            ? [getRegions.response.records.cicsregion]
-            : getRegions.response.records.cicsregion;
+            ? getPrograms.response.records.cicsprogram
+            : getPrograms.response.records.cicsprogram;
 
-          const listOfRegionNames: string[] = listOfRegions.map(
-            (region: { applid: string }) => region.applid
-          );
-
-          const regions = [];
-
-          for (const region of listOfRegions) {
-            const regionTreeItem = new CICSRegionTreeItem(
-              region.applid,
-              sessionTreeItem,
-              region,
-              []
+          for (const program of listOfPrograms) {
+            const programTreeItem = new CICSProgramTreeItem(
+              program,
+              regionTreeItem
             );
-
-            const getPrograms = await getResource(session, {
-              name: "CICSProgram",
-              regionName: region.applid,
-              cicsPlex: cicsPlex!,
-              criteria:
-                "NOT (PROGRAM=CEE* OR PROGRAM=DFH* OR PROGRAM=CJ* OR PROGRAM=EYU* OR PROGRAM=CSQ* OR PROGRAM=CEL* OR PROGRAM=IGZ*)",
-              parameter: undefined,
-            });
-
-            const listOfPrograms = !Array.isArray(
-              getPrograms.response.records.cicsprogram
-            )
-              ? getPrograms.response.records.cicsprogram
-              : getPrograms.response.records.cicsprogram;
-
-            for (const program of listOfPrograms) {
-              const programTreeItem = new CICSProgramTreeItem(
-                program,
-                regionTreeItem
-              );
-              regionTreeItem.addProgramChild(programTreeItem);
-            }
-
-            sessionTreeItem.addRegionChild(regionTreeItem);
-
-            regions.push({
-              [region.applid]: listOfPrograms,
-            });
+            regionTreeItem.addProgramChild(programTreeItem);
           }
 
-          listOfSessionTrees.push(sessionTreeItem);
+          sessionTreeItem.addRegionChild(regionTreeItem);
 
-          profileList.push({
-            name: sessionName,
-            session: session,
-            regions: regions,
-            cicsPlex: cicsPlex!,
+          regions.push({
+            [region.applid]: listOfPrograms,
           });
         }
-        this.data = listOfSessionTrees;
-        this._onDidChangeTreeData.fire(undefined);
-        this.hideStatusBarItem();
+
+        listOfSessionTrees.push(sessionTreeItem);
+
+        profileList.push({
+          name: sessionName,
+          session: session,
+          regions: regions,
+          cicsPlex: cicsPlex!,
+        });
       }
+      this.data = listOfSessionTrees;
+      this._onDidChangeTreeData.fire(undefined);
+      this.hideStatusBarItem();
     } catch (ex) {
       console.log(ex);
       window.showErrorMessage(ex);
+      this.hideStatusBarItem();
     }
   }
 
@@ -214,9 +218,17 @@ export class CICSTreeDataProvider
 
       let profileNameToLoad = await window.showQuickPick(
         profileStorage.getProfiles().map((prof) => {
-          return {
-            label: prof.name!,
-          };
+          let toReturn;
+          if (!this.sessionMap.has(prof.name!)) {
+            toReturn = {
+              label: prof.name!,
+            };
+          } else {
+            toReturn = {
+              label: "",
+            };
+          }
+          return toReturn;
         })
       );
 


### PR DESCRIPTION
Resolves #28.

Allows user to right-click a session node and remove it from the tree.

Signed-off-by: AndrewTwydell <u1858490@unimail.hud.ac.uk>