### PR TITLE
Remove refresh from newcopy and phase in

### DIFF
--- a/src/commands/newCopyCommand.ts
+++ b/src/commands/newCopyCommand.ts
@@ -33,7 +33,7 @@ export function getNewCopyCommand(tree: CICSTreeDataProvider) {
           window.showInformationMessage(
             `New Copy Count for ${node.label} - ${response.response.records.cicsprogram.newcopycnt}`
           );
-          tree.refresh();
+          // tree.refresh();
         } catch (err) {
           console.log(err);
 

--- a/src/commands/phaseInCommand.ts
+++ b/src/commands/phaseInCommand.ts
@@ -35,7 +35,7 @@ export function getPhaseInCommand(tree: CICSTreeDataProvider) {
           window.showInformationMessage(
             `New Copy Count for ${node.label} - ${response.response.records.cicsprogram.newcopycnt}`
           );
-          tree.refresh();
+          // tree.refresh();
         } catch (err) {
           console.log(err);
           window.showErrorMessage(err);
@@ -47,7 +47,7 @@ export function getPhaseInCommand(tree: CICSTreeDataProvider) {
 
 async function performPhaseIn(
   session: AbstractSession,
-  parms: { cicsPlex: string | null; regionName: string; name: string }
+  parms: { cicsPlex: string | null; regionName: string; name: string; }
 ) {
   const requestBody: any = {
     request: {


### PR DESCRIPTION
Resolves #54 .

This PR stops the Session Tree refreshing after a phase in and new copy, which stops it collapsing after the actions are performed. 

This does however mean the tree view must be refreshed manually if you required an updated attributes list.