### PR TITLE
show 'add profile' view when none exist

### DIFF
--- a/src/trees/treeProvider.ts
+++ b/src/trees/treeProvider.ts
@@ -277,6 +277,7 @@ export class CICSTreeDataProvider
         }
       }
     } else {
+      this.noProfiles();
       window.showInformationMessage(
         "No Profiles Found... Click the Add Session button to get started"
       );


### PR DESCRIPTION
Resolves #46 

Added a line that opens web view to create a profile if none are found when clicking 'Add new session'.