### PR TITLE
Updated webview text from session to profile

### DIFF
--- a/src/trees/treeProvider.ts
+++ b/src/trees/treeProvider.ts
@@ -303,7 +303,7 @@ export class CICSTreeDataProvider
       : undefined;
     const panel: WebviewPanel = window.createWebviewPanel(
       "zowe",
-      `Create Session`,
+      `Create CICS Profile`,
       column || 1,
       { enableScripts: true }
     );

--- a/src/trees/webviewHTML.ts
+++ b/src/trees/webviewHTML.ts
@@ -16,7 +16,7 @@ export const addProfileHtml = () => {
       <meta charset="UTF-8" />
       <meta http-equiv="X-UA-Compatible" content="IE=edge" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>Add Session</title>
+      <title>Create CICS Profile</title>
   
       <link
         rel="stylesheet"
@@ -89,7 +89,7 @@ export const addProfileHtml = () => {
     </style>
     <body>
       <div class="bx--content">
-        <h1>Add Session</h1>
+        <h1>Create CICS Profile</h1>
   
         <div
           class="


### PR DESCRIPTION
Closes #71 

Before, the webview to create a new CLI profile said `Add Session`. We have updated this to say `Create CICS Profile` as it's more descriptive and accurate.