### PR TITLE
updated webview to autofill region and plex

### DIFF
--- a/src/trees/webviewHTML.ts
+++ b/src/trees/webviewHTML.ts
@@ -270,13 +270,28 @@ export const addProfileHtml = () => {
               document.getElementById("ruSelect").value === "true" ? true : false,
             protocol: document.getElementById("protocol-select").value,
           };
-          const data = {
+          let data = {
             session: session,
-            name: document.getElementById("name-input").value,
-            region: document.getElementById("region-input").value,
-            cicsPlex: document.getElementById("plex-input").value,
+            name: document.getElementById("name-input").value.toString().trim(),
           };
-  
+
+          const givenRegion = document
+            .getElementById("region-input")
+            .value.toString()
+            .trim();
+          const givenPlex = document.getElementById("plex-input").value.toString().trim();
+
+          if (givenPlex.length > 0) {
+            data.cicsPlex = givenPlex;
+            if (givenRegion.length > 0) {
+              data.region = givenRegion;
+            } else {
+              data.region = givenPlex;
+            }
+          } else {
+            data.region = givenRegion;
+          }
+
           const vscode = acquireVsCodeApi();
           vscode.postMessage(data);
         }


### PR DESCRIPTION
Resolves #67 
Closes #47 

If connecting to a single region, an empty CICS Plex attribute will NOT be created in your profile.

If connecting to a Plex, you DON'T have to supply a region name when creating a profile.