### PR TITLE
Next open config to update

### DIFF
--- a/src/commands/updateSessionCommand.ts
+++ b/src/commands/updateSessionCommand.ts
@@ -9,10 +9,12 @@
 *
 */
 
+import { IProfAttrs } from "@zowe/imperative";
 import { commands, TreeView, window } from "vscode";
 import { CICSSessionTree } from "../trees/CICSSessionTree";
 import { CICSTree } from "../trees/CICSTree";
-import { findSelectedNodes } from "../utils/commandUtils";
+import { findSelectedNodes, openConfigFile } from "../utils/commandUtils";
+import { ProfileManagement } from "../utils/profileManagement";
 
 export function getUpdateSessionCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand(
@@ -23,13 +25,21 @@ export function getUpdateSessionCommand(tree: CICSTree, treeview: TreeView<any>)
         window.showErrorMessage("No profile selected to update");
         return;
       }
-      for (const sessionTree of allSelectedNodes) {
-        try {
-          await tree.updateSession(sessionTree);
-        } catch (error) {
-          window.showErrorMessage(`Something went wrong when updating the profile - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(/(\\n\t|\\n|\\t)/gm," ")}`);
-        }
+      const profilesCache = ProfileManagement.getProfilesCache();
+      const currentProfile: IProfAttrs = profilesCache.getProfileFromConfig(node.label);
+      if (currentProfile) {
+        //@ts-ignore
+        const filePath = currentProfile.profLoc.osLoc[0];
+        await openConfigFile(filePath);
       }
+      // // Previous Method:
+      // for (const sessionTree of allSelectedNodes) {
+      //   try {
+      //     await tree.updateSession(sessionTree);
+      //   } catch (error) {
+      //     window.showErrorMessage(`Something went wrong when updating the profile - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(/(\\n\t|\\n|\\t)/gm," ")}`);
+      //   }
+      // }
     }
   );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,9 +48,8 @@ import { getIconPathInResources } from "./utils/getIconPath";
 import { plexExpansionHandler } from "./utils/plexExpansionHandler";
 import { sessionExpansionHandler } from "./utils/sessionExpansionHandler";
 import { regionContainerExpansionHandler } from "./utils/regionContainerExpansionHandler";
-import { getSecurityModules, KeytarApi, ProfilesCache, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
-import cicsProfileMeta from "./utils/profileDefinition";
-import { CredentialManagerFactory, Logger, ProfileInfo } from "@zowe/imperative";
+import { KeytarApi } from "@zowe/zowe-explorer-api";
+import { CredentialManagerFactory, Logger } from "@zowe/imperative";
 import { isTheia } from "./utils/theiaCheck";
 
 export async function activate(context: ExtensionContext) {
@@ -59,27 +58,26 @@ export async function activate(context: ExtensionContext) {
   await keytarApi.activateKeytar(CredentialManagerFactory.initialized,isTheia());
   if (ProfileManagement.apiDoesExist()) {
     try {
-      const zoweExplorerAPI = ZoweVsCodeExtension.getZoweExplorerApi('2.0.0-next.202112161700');
-      await zoweExplorerAPI.getExplorerExtenderApi().initForZowe('cics', cicsProfileMeta);
-      zoweExplorerAPI.getExplorerExtenderApi().getProfilesCache().registerCustomProfilesType('cics');
-      await zoweExplorerAPI.getExplorerExtenderApi().reloadProfiles("cics");
+      await ProfileManagement.registerCICSProfiles();
+      ProfileManagement.getProfilesCache().registerCustomProfilesType('cics');
+      await ProfileManagement.getExplorerApis().getExplorerExtenderApi().reloadProfiles();
       
-      /**  
-       * 
-       * Testing ProfilesCache config methods 
-       * 
-       * */
-      const mProfileInfo = new ProfileInfo("zowe", {
-        requireKeytar: () => getSecurityModules("keytar", isTheia())!,
-      });
-      //const mProfileInfo = new ProfileInfo("zowe");
-      ProfilesCache.createConfigInstance(mProfileInfo);
-      const configInstance = ProfilesCache.getConfigInstance();
-      /**  
-       * 
-       * End of testing 
-       * 
-       * */
+      // /**  
+      //  * 
+      //  * Testing ProfilesCache config methods 
+      //  * 
+      //  * */
+      // const mProfileInfo = new ProfileInfo("zowe", {
+      //   requireKeytar: () => getSecurityModules("keytar", isTheia())!,
+      // });
+      // //const mProfileInfo = new ProfileInfo("zowe");
+      // ProfilesCache.createConfigInstance(mProfileInfo);
+      // const configInstance = ProfilesCache.getConfigInstance();
+      // /**  
+      //  * 
+      //  * End of testing 
+      //  * 
+      //  * */
       
       window.showInformationMessage(
         "Zowe Explorer was modified for the CICS Extension"

--- a/src/trees/CICSTree.ts
+++ b/src/trees/CICSTree.ts
@@ -68,9 +68,22 @@ export class CICSTree
 
             if (profileNameToLoad) {
                 if (profileNameToLoad.label.includes("\uFF0B")) {
-                    //  Create New Profile Form should appear
-
-                    this.createNewProfile();
+                    // const configName = ProfilesCache.getConfigInstance().getTeamConfig().configName;
+                    // let configDir = ProfilesCache.getConfigInstance().getTeamConfig().mHomeDir;
+                    // if (workspace.workspaceFolders) {
+                    //     // Check if config file is present in the workspace
+                    //     const uri = await workspace.findFiles(
+                    //         new RelativePattern(workspace.workspaceFolders[0], configName)
+                    //     );
+                    //     if (uri.length > 0) {
+                    //         configDir = ProfilesCache.getConfigInstance().getTeamConfig().mProjectDir;
+                    //     }
+                    // }
+                    // const filePath = path.join(configDir, configName);
+                    // await openConfigFile(filePath);
+                    window.showInformationMessage("Open and edit your config file to create a new profile");
+                    //  // Old method: Create New Profile Form should appear
+                    //this.createNewProfile();
 
                 } else {
                     const profileToLoad = ProfileManagement.getProfilesCache().loadNamedProfile(profileNameToLoad.label, 'cics');

--- a/src/utils/commandUtils.ts
+++ b/src/utils/commandUtils.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { TreeView } from "vscode";
+import { TreeView, window, workspace } from "vscode";
 
 /** 
  * Returns an array of selected nodes in the current treeview.
@@ -32,3 +32,8 @@ export function findSelectedNodes(treeview: TreeView<any>, instanceOf:any, click
     }
     return allSelectedNodes;
 }
+
+export async function openConfigFile(filePath: string) {
+    const document = await workspace.openTextDocument(filePath);
+    await window.showTextDocument(document);
+  }

--- a/src/utils/profileManagement.ts
+++ b/src/utils/profileManagement.ts
@@ -21,7 +21,7 @@ import { CICSPlexTree } from "../trees/CICSPlexTree";
 
 export class ProfileManagement {
 
-  private static zoweExplorerAPI = ZoweVsCodeExtension.getZoweExplorerApi('1.18.0');
+  private static zoweExplorerAPI = ZoweVsCodeExtension.getZoweExplorerApi('2.0.0-next.202112161700');
   private static profilesCache = ProfileManagement.zoweExplorerAPI.getExplorerExtenderApi().getProfilesCache();
 
   constructor() { }


### PR DESCRIPTION
Fixes #150 

- The config file is opened when a user wants to update a profile.
- A prompt is shown to tell the user to edit the config file manually if they want to add a new profile.