### PR TITLE
keep the Atribute Column Heading at top while scrolling

### DIFF
--- a/src/utils/webviewHTML.ts
+++ b/src/utils/webviewHTML.ts
@@ -442,7 +442,6 @@ export const getAttributesHtml = (title: string, webText: string) => {
       }
       .headingTH {
         padding: 0.7rem 0.5rem;
-        display: flex;
         flex-direction: column;
         align-items: center;
       }


### PR DESCRIPTION
Signed-off-by: Adarshdeep Cheema <adarshdeep.cheema@ibm.com>
It addresses: https://github.com/zowe/vscode-extension-for-cics/issues/268