### PR TITLE
fix(import, logging): Add logger util; remove keytar initialization

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,9 +53,8 @@ import { getIconPathInResources, setIconClosed } from "./utils/profileUtils";
 import { plexExpansionHandler } from "./utils/expansionHandler";
 import { sessionExpansionHandler } from "./utils/expansionHandler";
 import { regionContainerExpansionHandler } from "./utils/expansionHandler";
-import { getZoweExplorerVersion, isTheia } from "./utils/workspaceUtils";
-import { CredentialManagerFactory, Logger } from "@zowe/imperative";
-import { KeytarApi } from "@zowe/zowe-explorer-api";
+import { getZoweExplorerVersion } from "./utils/workspaceUtils";
+
 import { getInquireTransactionCommand } from "./commands/inquireTransaction";
 import { getPurgeTaskCommand } from "./commands/purgeTaskCommand";
 import { getInquireProgramCommand } from "./commands/inquireProgram";
@@ -66,9 +65,6 @@ import { getInquireProgramCommand } from "./commands/inquireProgram";
  * @returns 
  */
 export async function activate(context: ExtensionContext) {
-  const log = Logger.getAppLogger();
-  const keytarApi = new KeytarApi(log);
-  await keytarApi.activateKeytar(CredentialManagerFactory.initialized,isTheia());
   const zeVersion = getZoweExplorerVersion();
   if (!zeVersion){
     window.showErrorMessage("Zowe Explorer was not found: Please ensure Zowe Explorer v2.0.0 or higher is installed");

--- a/src/trees/CICSLibraryTree.ts
+++ b/src/trees/CICSLibraryTree.ts
@@ -66,7 +66,7 @@ export class CICSLibraryTree extends TreeItem {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if ((error as any)!.mMessage!.includes('exceeded a resource limit')) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a library filter to narrow search`);
-      } else if (this.children.length == 0) {
+      } else if (this.children.length === 0) {
         window.showInformationMessage(`No libraries found`);
         this.label = `Libraries${this.activeFilter?` (${this.activeFilter}) `: " "}[0]`;
       } else {

--- a/src/trees/CICSLocalFileTree.ts
+++ b/src/trees/CICSLocalFileTree.ts
@@ -72,7 +72,7 @@ export class CICSLocalFileTree extends TreeItem {
       if (error!.mMessage!.includes('exceeded a resource limit')) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a local file filter to narrow search`);
         // @ts-ignore
-      } else if (this.children.length == 0) {
+      } else if (this.children.length === 0) {
         window.showInformationMessage(`No local files found`);
         this.label = `Local Files${this.activeFilter?` (${this.activeFilter}) `: " "}[0]`;
       } else {

--- a/src/trees/CICSProgramTree.ts
+++ b/src/trees/CICSProgramTree.ts
@@ -65,7 +65,7 @@ export class CICSProgramTree extends TreeItem {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if ((error as any)!.mMessage!.includes('exceeded a resource limit')) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a program filter to narrow search`);
-      } else if ((this.children.length == 0)) {
+      } else if ((this.children.length === 0)) {
         window.showInformationMessage(`No programs found`);
         this.label = `Programs${this.activeFilter?` (${this.activeFilter}) `: " "}[0]`;
       } else {

--- a/src/trees/CICSTaskTree.ts
+++ b/src/trees/CICSTaskTree.ts
@@ -73,7 +73,7 @@ export class CICSTaskTree extends TreeItem {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if ((error as any)!.mMessage!.includes('exceeded a resource limit')) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a task filter to narrow search`);
-      } else if ((this.children.length == 0)) {
+      } else if ((this.children.length === 0)) {
         window.showInformationMessage(`No tasks found`);
         this.label = `Tasks${this.activeTransactionFilter?` (${this.activeTransactionFilter}) `: " "}[0]`;
       } else {

--- a/src/trees/CICSTransactionTree.ts
+++ b/src/trees/CICSTransactionTree.ts
@@ -68,7 +68,7 @@ export class CICSTransactionTree extends TreeItem {
       if (error!.mMessage!.includes('exceeded a resource limit')) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a transaction filter to narrow search`);
         // @ts-ignore
-      } else if ((this.children.length == 0)) {
+      } else if ((this.children.length === 0)) {
         window.showInformationMessage(`No transactions found`);
         this.label = `Transactions${this.activeFilter?` (${this.activeFilter}) `: " "}[0]`;
       } else {

--- a/src/trees/treeItems/CICSLibraryDatasets.ts
+++ b/src/trees/treeItems/CICSLibraryDatasets.ts
@@ -85,7 +85,7 @@ export class CICSLibraryDatasets extends TreeItem {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if ((error as any)!.mMessage!.includes('exceeded a resource limit')) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a program filter to narrow search`);
-      } else if (this.children.length == 0) {
+      } else if (this.children.length === 0) {
         window.showInformationMessage(`No programs found`);
         this.label = `${this.dataset.dsname}${this.activeFilter?` (${this.activeFilter}) `: " "}[0]`;
       } else {

--- a/src/trees/treeItems/CICSLibraryTreeItem.ts
+++ b/src/trees/treeItems/CICSLibraryTreeItem.ts
@@ -84,7 +84,7 @@ export class CICSLibraryTreeItem extends TreeItem {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if ((error as any)!.mMessage!.includes('exceeded a resource limit')) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a datasets filter to narrow search`);
-      } else if (this.children.length == 0) {
+      } else if (this.children.length === 0) {
         window.showInformationMessage(`No datasets found`);
         this.label = `${this.library.name}${this.parentRegion.parentPlex ? ` (${this.library.eyu_cicsname})` : ""}${this.activeFilter?` (${this.activeFilter}) `: " "}[0]`;
       } else {

--- a/src/trees/treeItems/web/CICSPipelineTree.ts
+++ b/src/trees/treeItems/web/CICSPipelineTree.ts
@@ -66,7 +66,7 @@ export class CICSPipelineTree extends TreeItem {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if ((error as any)!.mMessage!.includes('exceeded a resource limit')) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a Pipeline filter to narrow search`);
-      } else if ((this.children.length == 0)) {
+      } else if ((this.children.length === 0)) {
         window.showInformationMessage(`No Pipelines found`);
         this.label = `Pipelines${this.activeFilter?` (${this.activeFilter}) `: " "}[0]`;
       } else {

--- a/src/trees/treeItems/web/CICSTCPIPServiceTree.ts
+++ b/src/trees/treeItems/web/CICSTCPIPServiceTree.ts
@@ -66,7 +66,7 @@ export class CICSTCPIPServiceTree extends TreeItem {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if ((error as any)!.mMessage!.includes('exceeded a resource limit')) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a TCPIPService filter to narrow search`);
-      } else if ((this.children.length == 0)) {
+      } else if ((this.children.length === 0)) {
         window.showInformationMessage(`No TCPIP Services found`);
         this.label = `TCPIP Services${this.activeFilter?` (${this.activeFilter}) `: " "}[0]`;
       } else {

--- a/src/trees/treeItems/web/CICSURIMapTree.ts
+++ b/src/trees/treeItems/web/CICSURIMapTree.ts
@@ -66,7 +66,7 @@ export class CICSURIMapTree extends TreeItem {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if ((error as any)!.mMessage!.includes('exceeded a resource limit')) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a URIMap filter to narrow search`);
-      } else if ((this.children.length == 0)) {
+      } else if ((this.children.length === 0)) {
         window.showInformationMessage(`No URI Maps found`);
         this.label = `URI Maps${this.activeFilter?` (${this.activeFilter}) `: " "}[0]`;
       } else {

--- a/src/trees/treeItems/web/CICSWebServiceTree.ts
+++ b/src/trees/treeItems/web/CICSWebServiceTree.ts
@@ -66,7 +66,7 @@ export class CICSWebServiceTree extends TreeItem {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if ((error as any)!.mMessage!.includes('exceeded a resource limit')) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a Web Services filter to narrow search`);
-      } else if ((this.children.length == 0)) {
+      } else if ((this.children.length === 0)) {
         window.showInformationMessage(`No Web Services found`);
         this.label = `Web Services${this.activeFilter?` (${this.activeFilter}) `: " "}[0]`;
       } else {

--- a/src/utils/loggerUtils.ts
+++ b/src/utils/loggerUtils.ts
@@ -1,0 +1,15 @@
+import { IZoweLogger, getZoweDir } from "@zowe/zowe-explorer-api";
+import { join as joinPaths } from "path";
+
+export class LoggerUtil {
+    // Explicit null typing used to satisfy linter rule "eqeqeq"
+    static loggerObj: IZoweLogger | null = null;
+
+    public static get instance(): IZoweLogger {
+        if (LoggerUtil.loggerObj === null) {
+            LoggerUtil.loggerObj = new IZoweLogger("vscode-extension-for-cics", joinPaths(getZoweDir(), "vscode-extension-for-cics"));
+        }
+
+        return LoggerUtil.loggerObj;
+    }
+}

--- a/src/utils/profileManagement.ts
+++ b/src/utils/profileManagement.ts
@@ -10,7 +10,7 @@
 *
 */
 
-import { IDeleteProfile, IProfileLoaded, ISaveProfile, IUpdateProfile, Logger, ProfileInfo } from "@zowe/imperative";
+import { IDeleteProfile, IProfileLoaded, ISaveProfile, IUpdateProfile, ProfileInfo } from "@zowe/imperative";
 import { ProfilesCache, ZoweExplorerApi, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
 import axios, { AxiosRequestConfig } from "axios";
 import { window } from "vscode";
@@ -18,10 +18,11 @@ import { xml2json } from "xml-js";
 import cicsProfileMeta from "./profileDefinition";
 import * as https from "https";
 import { CICSPlexTree } from "../trees/CICSPlexTree";
+import { LoggerUtil } from "./loggerUtils";
 
 export class ProfileManagement {
   private static zoweExplorerAPI = ZoweVsCodeExtension.getZoweExplorerApi();
-  private static ProfilesCache = new ProfilesCache(Logger.getAppLogger());
+  private static ProfilesCache = new ProfilesCache(LoggerUtil.instance.getImperativeLogger());
   
   constructor() { }
 


### PR DESCRIPTION
This pull request would resolve a couple issues encountered when using the CICS extension:

- Instead of using the imperative logger, Zowe Explorer API includes a logger class to facilitate creating instances of the Imperative logger specifically for extensions (`IZoweLogger`). This PR proposes the implementation of a small "logger utility" singleton `LoggerUtil` that can be utilized from anywhere within the CICS extension. Currently I've designated the path in the code to be the `.zowe/vscode-extension-for-cics` folder, but this can be changed to any preferred path.
  - This was ultimately implemented to avoid issues with importing `imperative` from other extensions - for example, an error occurred w/ the CICS extension when trying to load the imperative app logger alongside the current version of Workflows4z. But as mentioned earlier, this class is also the suggested logger facility for use within Zowe Explorer extenders.
- Removal of the `KeytarApi` initialization logic: Zowe Explorer already initializes the `KeytarApi` for initial operations, so re-initialization is not needed. I've also proposed this removal as it might introduce issues with Keytar due to this re-initialization.
- Resolved linter warnings for `eqeqeq` rule.